### PR TITLE
Fix resolveType after the schema has been extended

### DIFF
--- a/src/types/entity.js
+++ b/src/types/entity.js
@@ -4,9 +4,19 @@ import { mbid, connectionWithExtras } from './helpers'
 const Entity = new GraphQLInterfaceType({
   name: 'Entity',
   description: 'An entity in the MusicBrainz schema.',
-  resolveType(value) {
-    if (value._type && require.resolve(`./${value._type}`)) {
-      return require(`./${value._type}`).default
+  resolveType(value, context, info) {
+    if (value._type) {
+      const typeMap = info.schema.getTypeMap()
+      let originalType
+      try {
+        originalType = require(`./${value._type}`).default
+      } catch (err) {
+        return
+      }
+      // Don't use `originalType`! The schema may have been extended in which
+      // case the types have all been replaced. Instead, find the current type
+      // of the same name.
+      return typeMap[originalType.name]
     }
   },
   fields: () => ({ mbid })


### PR DESCRIPTION
See explanation at graphql/graphql-js#1093.

Fixes #49.