### PR TITLE
Use graphql-tag on extension schemas to get syntax highlighting

### DIFF
--- a/docs/extensions/the-audio-db.md
+++ b/docs/extensions/the-audio-db.md
@@ -643,7 +643,11 @@ A description of the track.
 <tr>
 <td colspan="2" align="right" valign="top">lang</td>
 <td valign="top"><a href="../types.md#string">String</a></td>
-<td></td>
+<td>
+
+The two-letter code for the language in which to retrieve the description.
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>thumbnail</strong></td>

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "express-graphql": "^0.6.7",
     "graphql": "^0.11.7",
     "graphql-relay": "^0.5.2",
+    "graphql-tag": "^2.5.0",
     "graphql-tools": "^2.7.2",
     "lru-cache": "^4.1.1",
     "pascalcase": "^0.1.1",
@@ -113,7 +114,7 @@
     "graphql-markdown": "^3.2.0",
     "nodemon": "^1.11.0",
     "nyc": "^11.3.0",
-    "prettier": "^1.8.2",
+    "prettier": "prettier/prettier#4b070c3",
     "rimraf": "^2.6.1",
     "sepia": "^2.0.2",
     "sinon": "^4.1.2"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "express-graphql": "^0.6.7",
     "graphql": "^0.11.7",
     "graphql-relay": "^0.5.2",
-    "graphql-tag": "^2.5.0",
     "graphql-tools": "^2.7.2",
     "lru-cache": "^4.1.1",
     "pascalcase": "^0.1.1",

--- a/src/extensions/cover-art-archive/schema.js
+++ b/src/extensions/cover-art-archive/schema.js
@@ -1,121 +1,121 @@
-export default `
+import gql from 'graphql-tag'
 
-# An individual piece of album artwork from the [Cover Art Archive](https://musicbrainz.org/doc/Cover_Art_Archive).
-type CoverArtArchiveImage {
-  # The Internet Archive’s internal file ID for the image.
-  fileID: String!
+export default gql`
+  # An individual piece of album artwork from the [Cover Art Archive](https://musicbrainz.org/doc/Cover_Art_Archive).
+  type CoverArtArchiveImage {
+    # The Internet Archive’s internal file ID for the image.
+    fileID: String!
 
-  # The URL at which the image can be found.
-  image: URLString!
+    # The URL at which the image can be found.
+    image: URLString!
 
-  # A set of thumbnails for the image.
-  thumbnails: CoverArtArchiveImageThumbnails!
+    # A set of thumbnails for the image.
+    thumbnails: CoverArtArchiveImageThumbnails!
 
-  # Whether this image depicts the “main front” of the release.
-  front: Boolean!
+    # Whether this image depicts the “main front” of the release.
+    front: Boolean!
 
-  # Whether this image depicts the “main back” of the release.
-  back: Boolean!
+    # Whether this image depicts the “main back” of the release.
+    back: Boolean!
 
-  # A list of [image types](https://musicbrainz.org/doc/Cover_Art/Types)
-  # describing what part(s) of the release the image includes.
-  types: [String]!
+    # A list of [image types](https://musicbrainz.org/doc/Cover_Art/Types)
+    # describing what part(s) of the release the image includes.
+    types: [String]!
 
-  # The MusicBrainz edit ID.
-  edit: Int
+    # The MusicBrainz edit ID.
+    edit: Int
 
-  # Whether the image was approved by the MusicBrainz edit system.
-  approved: Boolean
+    # Whether the image was approved by the MusicBrainz edit system.
+    approved: Boolean
 
-  # A free-text comment left for the image.
-  comment: String
-}
+    # A free-text comment left for the image.
+    comment: String
+  }
 
-# The image sizes that may be requested at the [Cover Art Archive](https://musicbrainz.org/doc/Cover_Art_Archive).
-enum CoverArtArchiveImageSize {
-  # A maximum dimension of 250px.
-  SMALL
+  # The image sizes that may be requested at the [Cover Art Archive](https://musicbrainz.org/doc/Cover_Art_Archive).
+  enum CoverArtArchiveImageSize {
+    # A maximum dimension of 250px.
+    SMALL
 
-  # A maximum dimension of 500px.
-  LARGE
+    # A maximum dimension of 500px.
+    LARGE
 
-  # The image’s original dimensions, with no maximum.
-  FULL
-}
+    # The image’s original dimensions, with no maximum.
+    FULL
+  }
 
-# URLs for thumbnails of different sizes for a particular piece of
-# cover art.
-type CoverArtArchiveImageThumbnails {
-  # The URL of a small version of the cover art, where the maximum dimension is
-  # 250px.
-  small: URLString
+  # URLs for thumbnails of different sizes for a particular piece of
+  # cover art.
+  type CoverArtArchiveImageThumbnails {
+    # The URL of a small version of the cover art, where the maximum dimension is
+    # 250px.
+    small: URLString
 
-  # The URL of a large version of the cover art, where the maximum dimension is
-  # 500px.
-  large: URLString
-}
+    # The URL of a large version of the cover art, where the maximum dimension is
+    # 500px.
+    large: URLString
+  }
 
-# An object containing a list of the cover art images for a release obtained
-# from the [Cover Art Archive](https://musicbrainz.org/doc/Cover_Art_Archive),
-# as well as a summary of what artwork is available.
-type CoverArtArchiveRelease {
-  # The URL of an image depicting the album cover or “main front” of the release,
-  # i.e. the front of the packaging of the audio recording (or in the case of a
-  # digital release, the image associated with it in a digital media store).
-  #
-  # In the MusicBrainz schema, this field is a Boolean value indicating the
-  # presence of a front image, whereas here the value is the URL for the image
-  # itself if one exists. You can check for null if you just want to determine
-  # the presence of an image.
-  front(
-    # The size of the image to retrieve. By default, the returned image will
-    # have its full original dimensions, but certain thumbnail sizes may be
-    # retrieved as well.
-    size: CoverArtArchiveImageSize = FULL
-  ): URLString
+  # An object containing a list of the cover art images for a release obtained
+  # from the [Cover Art Archive](https://musicbrainz.org/doc/Cover_Art_Archive),
+  # as well as a summary of what artwork is available.
+  type CoverArtArchiveRelease {
+    # The URL of an image depicting the album cover or “main front” of the release,
+    # i.e. the front of the packaging of the audio recording (or in the case of a
+    # digital release, the image associated with it in a digital media store).
+    #
+    # In the MusicBrainz schema, this field is a Boolean value indicating the
+    # presence of a front image, whereas here the value is the URL for the image
+    # itself if one exists. You can check for null if you just want to determine
+    # the presence of an image.
+    front(
+      # The size of the image to retrieve. By default, the returned image will
+      # have its full original dimensions, but certain thumbnail sizes may be
+      # retrieved as well.
+      size: CoverArtArchiveImageSize = FULL
+    ): URLString
 
-  # The URL of an image depicting the “main back” of the release, i.e. the back
-  # of the packaging of the audio recording.
-  #
-  # In the MusicBrainz schema, this field is a Boolean value indicating the
-  # presence of a back image, whereas here the value is the URL for the image
-  # itself. You can check for null if you just want to determine the presence of
-  # an image.
-  back(
-    # The size of the image to retrieve. By default, the returned image will
-    # have its full original dimensions, but certain thumbnail sizes may be
-    # retrieved as well.
-    size: CoverArtArchiveImageSize = FULL
-  ): URLString
+    # The URL of an image depicting the “main back” of the release, i.e. the back
+    # of the packaging of the audio recording.
+    #
+    # In the MusicBrainz schema, this field is a Boolean value indicating the
+    # presence of a back image, whereas here the value is the URL for the image
+    # itself. You can check for null if you just want to determine the presence of
+    # an image.
+    back(
+      # The size of the image to retrieve. By default, the returned image will
+      # have its full original dimensions, but certain thumbnail sizes may be
+      # retrieved as well.
+      size: CoverArtArchiveImageSize = FULL
+    ): URLString
 
-  # A list of images depicting the different sides and surfaces of a release’s
-  # media and packaging.
-  images: [CoverArtArchiveImage]!
+    # A list of images depicting the different sides and surfaces of a release’s
+    # media and packaging.
+    images: [CoverArtArchiveImage]!
 
-  # Whether there is artwork present for this release.
-  artwork: Boolean!
+    # Whether there is artwork present for this release.
+    artwork: Boolean!
 
-  # The number of artwork images present for this release.
-  count: Int!
+    # The number of artwork images present for this release.
+    count: Int!
 
-  # The particular release shown in the returned cover art.
-  release: Release
-}
+    # The particular release shown in the returned cover art.
+    release: Release
+  }
 
-extend type Release {
-  # An object containing a list and summary of the cover art images that are
-  # present for this release from the [Cover Art Archive](https://musicbrainz.org/doc/Cover_Art_Archive).
-  # This field is provided by the Cover Art Archive extension.
-  coverArtArchive: CoverArtArchiveRelease
-}
+  extend type Release {
+    # An object containing a list and summary of the cover art images that are
+    # present for this release from the [Cover Art Archive](https://musicbrainz.org/doc/Cover_Art_Archive).
+    # This field is provided by the Cover Art Archive extension.
+    coverArtArchive: CoverArtArchiveRelease
+  }
 
-extend type ReleaseGroup {
-  # The cover art for a release in the release group, obtained from the
-  # [Cover Art Archive](https://musicbrainz.org/doc/Cover_Art_Archive). A
-  # release in the release group will be chosen as representative of the release
-  # group.
-  # This field is provided by the Cover Art Archive extension.
-  coverArtArchive: CoverArtArchiveRelease
-}
-
+  extend type ReleaseGroup {
+    # The cover art for a release in the release group, obtained from the
+    # [Cover Art Archive](https://musicbrainz.org/doc/Cover_Art_Archive). A
+    # release in the release group will be chosen as representative of the release
+    # group.
+    # This field is provided by the Cover Art Archive extension.
+    coverArtArchive: CoverArtArchiveRelease
+  }
 `

--- a/src/extensions/cover-art-archive/schema.js
+++ b/src/extensions/cover-art-archive/schema.js
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag'
+import gql from '../../tag'
 
 export default gql`
   # An individual piece of album artwork from the [Cover Art Archive](https://musicbrainz.org/doc/Cover_Art_Archive).

--- a/src/extensions/fanart-tv/schema.js
+++ b/src/extensions/fanart-tv/schema.js
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag'
+import gql from '../../tag'
 
 export default gql`
   # The image sizes that may be requested at [fanart.tv](https://fanart.tv/).

--- a/src/extensions/fanart-tv/schema.js
+++ b/src/extensions/fanart-tv/schema.js
@@ -1,127 +1,127 @@
-export default `
+import gql from 'graphql-tag'
 
-# The image sizes that may be requested at [fanart.tv](https://fanart.tv/).
-enum FanArtImageSize {
-  # The image’s full original dimensions.
-  FULL
+export default gql`
+  # The image sizes that may be requested at [fanart.tv](https://fanart.tv/).
+  enum FanArtImageSize {
+    # The image’s full original dimensions.
+    FULL
 
-  # A maximum dimension of 200px.
-  PREVIEW
-}
+    # A maximum dimension of 200px.
+    PREVIEW
+  }
 
-# A single image from [fanart.tv](https://fanart.tv/).
-type FanArtImage {
-  # The ID of the image on fanart.tv.
-  imageID: ID
+  # A single image from [fanart.tv](https://fanart.tv/).
+  type FanArtImage {
+    # The ID of the image on fanart.tv.
+    imageID: ID
 
-  # The URL of the image.
-  url(
-    # The size of the image to retrieve.
-    size: FanArtImageSize = FULL
-  ): URLString
+    # The URL of the image.
+    url(
+      # The size of the image to retrieve.
+      size: FanArtImageSize = FULL
+    ): URLString
 
-  # The number of likes the image has received by fanart.tv users.
-  likeCount: Int
-}
+    # The number of likes the image has received by fanart.tv users.
+    likeCount: Int
+  }
 
-# A disc image from [fanart.tv](https://fanart.tv/).
-type FanArtDiscImage {
-  # The ID of the image on fanart.tv.
-  imageID: ID
+  # A disc image from [fanart.tv](https://fanart.tv/).
+  type FanArtDiscImage {
+    # The ID of the image on fanart.tv.
+    imageID: ID
 
-  # The URL of the image.
-  url(
-    # The size of the image to retrieve.
-    size: FanArtImageSize = FULL
-  ): URLString
+    # The URL of the image.
+    url(
+      # The size of the image to retrieve.
+      size: FanArtImageSize = FULL
+    ): URLString
 
-  # The number of likes the image has received by fanart.tv users.
-  likeCount: Int
+    # The number of likes the image has received by fanart.tv users.
+    likeCount: Int
 
-  # The disc number.
-  discNumber: Int
+    # The disc number.
+    discNumber: Int
 
-  # The width and height of the (square) disc image.
-  size: Int
-}
+    # The width and height of the (square) disc image.
+    size: Int
+  }
 
-# A music label image from [fanart.tv](https://fanart.tv/).
-type FanArtLabelImage {
-  # The ID of the image on fanart.tv.
-  imageID: ID
+  # A music label image from [fanart.tv](https://fanart.tv/).
+  type FanArtLabelImage {
+    # The ID of the image on fanart.tv.
+    imageID: ID
 
-  # The URL of the image.
-  url(
-    # The size of the image to retrieve.
-    size: FanArtImageSize = FULL
-  ): URLString
+    # The URL of the image.
+    url(
+      # The size of the image to retrieve.
+      size: FanArtImageSize = FULL
+    ): URLString
 
-  # The number of likes the image has received by fanart.tv users.
-  likeCount: Int
+    # The number of likes the image has received by fanart.tv users.
+    likeCount: Int
 
-  # The type of color content in the image (usually “white” or “colour”).
-  color: String
-}
+    # The type of color content in the image (usually “white” or “colour”).
+    color: String
+  }
 
-# An object containing lists of the different types of artist images from
-# [fanart.tv](https://fanart.tv/).
-type FanArtArtist {
-  # A list of 1920x1080 JPG images picturing the artist, suitable for use as
-  # backgrounds.
-  backgrounds: [FanArtImage]
+  # An object containing lists of the different types of artist images from
+  # [fanart.tv](https://fanart.tv/).
+  type FanArtArtist {
+    # A list of 1920x1080 JPG images picturing the artist, suitable for use as
+    # backgrounds.
+    backgrounds: [FanArtImage]
 
-  # A list of 1000x185 JPG images containing the artist and their logo or name.
-  banners: [FanArtImage]
+    # A list of 1000x185 JPG images containing the artist and their logo or name.
+    banners: [FanArtImage]
 
-  # A list of 400x155 PNG images containing the artist’s logo or name, with
-  # transparent backgrounds.
-  logos: [FanArtImage]
+    # A list of 400x155 PNG images containing the artist’s logo or name, with
+    # transparent backgrounds.
+    logos: [FanArtImage]
 
-  # A list of 800x310 PNG images containing the artist’s logo or name, with
-  # transparent backgrounds.
-  logosHD: [FanArtImage]
+    # A list of 800x310 PNG images containing the artist’s logo or name, with
+    # transparent backgrounds.
+    logosHD: [FanArtImage]
 
-  # A list of 1000x1000 JPG thumbnail images picturing the artist (usually
-  # containing every member of a band).
-  thumbnails: [FanArtImage]
-}
+    # A list of 1000x1000 JPG thumbnail images picturing the artist (usually
+    # containing every member of a band).
+    thumbnails: [FanArtImage]
+  }
 
-# An object containing lists of the different types of label images from
-# [fanart.tv](https://fanart.tv/).
-type FanArtLabel {
-  # A list of 400x270 PNG images containing the label’s logo. There will
-  # usually be a black version, a color version, and a white version, all with
-  # transparent backgrounds.
-  logos: [FanArtLabelImage]
-}
+  # An object containing lists of the different types of label images from
+  # [fanart.tv](https://fanart.tv/).
+  type FanArtLabel {
+    # A list of 400x270 PNG images containing the label’s logo. There will
+    # usually be a black version, a color version, and a white version, all with
+    # transparent backgrounds.
+    logos: [FanArtLabelImage]
+  }
 
-# An object containing lists of the different types of release group images from
-# [fanart.tv](https://fanart.tv/).
-type FanArtAlbum {
-  # A list of 1000x1000 JPG images of the cover artwork of the release group.
-  albumCovers: [FanArtImage]
+  # An object containing lists of the different types of release group images from
+  # [fanart.tv](https://fanart.tv/).
+  type FanArtAlbum {
+    # A list of 1000x1000 JPG images of the cover artwork of the release group.
+    albumCovers: [FanArtImage]
 
-  # A list of 1000x1000 PNG images of the physical disc media for the release
-  # group, with transparent backgrounds.
-  discImages: [FanArtDiscImage]
-}
+    # A list of 1000x1000 PNG images of the physical disc media for the release
+    # group, with transparent backgrounds.
+    discImages: [FanArtDiscImage]
+  }
 
-extend type Artist {
-  # Images of the artist from [fanart.tv](https://fanart.tv/).
-  # This field is provided by the fanart.tv extension.
-  fanArt: FanArtArtist
-}
+  extend type Artist {
+    # Images of the artist from [fanart.tv](https://fanart.tv/).
+    # This field is provided by the fanart.tv extension.
+    fanArt: FanArtArtist
+  }
 
-extend type Label {
-  # Images of the label from [fanart.tv](https://fanart.tv/).
-  # This field is provided by the fanart.tv extension.
-  fanArt: FanArtLabel
-}
+  extend type Label {
+    # Images of the label from [fanart.tv](https://fanart.tv/).
+    # This field is provided by the fanart.tv extension.
+    fanArt: FanArtLabel
+  }
 
-extend type ReleaseGroup {
-  # Images of the release group from [fanart.tv](https://fanart.tv/).
-  # This field is provided by the fanart.tv extension.
-  fanArt: FanArtAlbum
-}
-
+  extend type ReleaseGroup {
+    # Images of the release group from [fanart.tv](https://fanart.tv/).
+    # This field is provided by the fanart.tv extension.
+    fanArt: FanArtAlbum
+  }
 `

--- a/src/extensions/mediawiki/schema.js
+++ b/src/extensions/mediawiki/schema.js
@@ -1,110 +1,110 @@
-export default `
+import gql from 'graphql-tag'
 
-# An object describing various properties of an image stored on a MediaWiki
-# server. The information comes the [MediaWiki imageinfo API](https://www.mediawiki.org/wiki/API:Imageinfo).
-type MediaWikiImage {
-  # The URL of the actual image file.
-  url: URLString!
+export default gql`
+  # An object describing various properties of an image stored on a MediaWiki
+  # server. The information comes the [MediaWiki imageinfo API](https://www.mediawiki.org/wiki/API:Imageinfo).
+  type MediaWikiImage {
+    # The URL of the actual image file.
+    url: URLString!
 
-  # The URL of the wiki page describing the image.
-  descriptionURL: URLString
+    # The URL of the wiki page describing the image.
+    descriptionURL: URLString
 
-  # The user who uploaded the file.
-  user: String
+    # The user who uploaded the file.
+    user: String
 
-  # The size of the file in bytes.
-  size: Int
+    # The size of the file in bytes.
+    size: Int
 
-  # The pixel width of the image.
-  width: Int
+    # The pixel width of the image.
+    width: Int
 
-  # The pixel height of the image.
-  height: Int
+    # The pixel height of the image.
+    height: Int
 
-  # The canonical title of the file.
-  canonicalTitle: String
+    # The canonical title of the file.
+    canonicalTitle: String
 
-  # The image title, brief description, or file name.
-  objectName: String
+    # The image title, brief description, or file name.
+    objectName: String
 
-  # A description of the image, potentially containing HTML.
-  descriptionHTML: String
+    # A description of the image, potentially containing HTML.
+    descriptionHTML: String
 
-  # The original date of creation of the image. May be a description rather than
-  # a parseable timestamp, and may contain HTML.
-  originalDateTimeHTML: String
+    # The original date of creation of the image. May be a description rather than
+    # a parseable timestamp, and may contain HTML.
+    originalDateTimeHTML: String
 
-  # A list of the categories of the image.
-  categories: [String]!
+    # A list of the categories of the image.
+    categories: [String]!
 
-  # The name of the image author, potentially containing HTML.
-  artistHTML: String
+    # The name of the image author, potentially containing HTML.
+    artistHTML: String
 
-  # The source of the image, potentially containing HTML.
-  creditHTML: String
+    # The source of the image, potentially containing HTML.
+    creditHTML: String
 
-  # A short human-readable license name.
-  licenseShortName: String
+    # A short human-readable license name.
+    licenseShortName: String
 
-  # A web address where the license is described.
-  licenseURL: URLString
+    # A web address where the license is described.
+    licenseURL: URLString
 
-  # The full list of values in the \`extmetadata\` field.
-  metadata: [MediaWikiImageMetadata]!
-}
+    # The full list of values in the \`extmetadata\` field.
+    metadata: [MediaWikiImageMetadata]!
+  }
 
-# An entry in the \`extmetadata\` field of a MediaWiki image file.
-type MediaWikiImageMetadata {
-  # The name of the metadata field.
-  name: String!
-  # The value of the metadata field. All values will be converted to strings.
-  value: String
-  # The source of the value.
-  source: String
-}
+  # An entry in the \`extmetadata\` field of a MediaWiki image file.
+  type MediaWikiImageMetadata {
+    # The name of the metadata field.
+    name: String!
+    # The value of the metadata field. All values will be converted to strings.
+    value: String
+    # The source of the value.
+    source: String
+  }
 
-extend type Artist {
-  # Artist images found at MediaWiki URLs in the artist’s URL relationships.
-  # Defaults to URL relationships with the type “image”.
-  # This field is provided by the MediaWiki extension.
-  mediaWikiImages(
-    # The type of URL relationship that will be selected to find images. See
-    # the possible [Artist-URL relationship types](https://musicbrainz.org/relationships/artist-url).
-    type: String = "image"
-  ): [MediaWikiImage]!
-}
+  extend type Artist {
+    # Artist images found at MediaWiki URLs in the artist’s URL relationships.
+    # Defaults to URL relationships with the type “image”.
+    # This field is provided by the MediaWiki extension.
+    mediaWikiImages(
+      # The type of URL relationship that will be selected to find images. See
+      # the possible [Artist-URL relationship types](https://musicbrainz.org/relationships/artist-url).
+      type: String = "image"
+    ): [MediaWikiImage]!
+  }
 
-extend type Instrument {
-  # Instrument images found at MediaWiki URLs in the instrument’s URL
-  # relationships. Defaults to URL relationships with the type “image”.
-  # This field is provided by the MediaWiki extension.
-  mediaWikiImages(
-    # The type of URL relationship that will be selected to find images. See the
-    # possible [Instrument-URL relationship types](https://musicbrainz.org/relationships/instrument-url).
-    type: String = "image"
-  ): [MediaWikiImage]!
-}
+  extend type Instrument {
+    # Instrument images found at MediaWiki URLs in the instrument’s URL
+    # relationships. Defaults to URL relationships with the type “image”.
+    # This field is provided by the MediaWiki extension.
+    mediaWikiImages(
+      # The type of URL relationship that will be selected to find images. See the
+      # possible [Instrument-URL relationship types](https://musicbrainz.org/relationships/instrument-url).
+      type: String = "image"
+    ): [MediaWikiImage]!
+  }
 
-extend type Label {
-  # Label images found at MediaWiki URLs in the label’s URL relationships.
-  # Defaults to URL relationships with the type “logo”.
-  # This field is provided by the MediaWiki extension.
-  mediaWikiImages(
-    # The type of URL relationship that will be selected to find images. See the
-    # possible [Label-URL relationship types](https://musicbrainz.org/relationships/label-url).
-    type: String = "logo"
-  ): [MediaWikiImage]!
-}
+  extend type Label {
+    # Label images found at MediaWiki URLs in the label’s URL relationships.
+    # Defaults to URL relationships with the type “logo”.
+    # This field is provided by the MediaWiki extension.
+    mediaWikiImages(
+      # The type of URL relationship that will be selected to find images. See the
+      # possible [Label-URL relationship types](https://musicbrainz.org/relationships/label-url).
+      type: String = "logo"
+    ): [MediaWikiImage]!
+  }
 
-extend type Place {
-  # Place images found at MediaWiki URLs in the place’s URL relationships.
-  # Defaults to URL relationships with the type “image”.
-  # This field is provided by the MediaWiki extension.
-  mediaWikiImages(
-    # The type of URL relationship that will be selected to find images. See the
-    # possible [Place-URL relationship types](https://musicbrainz.org/relationships/place-url).
-    type: String = "image"
-  ): [MediaWikiImage]!
-}
-
+  extend type Place {
+    # Place images found at MediaWiki URLs in the place’s URL relationships.
+    # Defaults to URL relationships with the type “image”.
+    # This field is provided by the MediaWiki extension.
+    mediaWikiImages(
+      # The type of URL relationship that will be selected to find images. See the
+      # possible [Place-URL relationship types](https://musicbrainz.org/relationships/place-url).
+      type: String = "image"
+    ): [MediaWikiImage]!
+  }
 `

--- a/src/extensions/mediawiki/schema.js
+++ b/src/extensions/mediawiki/schema.js
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag'
+import gql from '../../tag'
 
 export default gql`
   # An object describing various properties of an image stored on a MediaWiki

--- a/src/extensions/the-audio-db/schema.js
+++ b/src/extensions/the-audio-db/schema.js
@@ -1,231 +1,232 @@
-export default `
+import gql from 'graphql-tag'
 
-# The image sizes that may be requested at [TheAudioDB](http://www.theaudiodb.com/).
-enum TheAudioDBImageSize {
-  # The image’s full original dimensions.
-  FULL
+export default gql`
+  # The image sizes that may be requested at [TheAudioDB](http://www.theaudiodb.com/).
+  enum TheAudioDBImageSize {
+    # The image’s full original dimensions.
+    FULL
 
-  # A maximum dimension of 200px.
-  PREVIEW
-}
+    # A maximum dimension of 200px.
+    PREVIEW
+  }
 
-# An artist on [TheAudioDB](http://www.theaudiodb.com/).
-type TheAudioDBArtist {
-  # TheAudioDB ID of the artist.
-  artistID: ID
+  # An artist on [TheAudioDB](http://www.theaudiodb.com/).
+  type TheAudioDBArtist {
+    # TheAudioDB ID of the artist.
+    artistID: ID
 
-  # A biography of the artist, often available in several languages.
-  biography(
-    # The two-letter code for the language in which to retrieve the biography.
-    lang: String = "en"
-  ): String
+    # A biography of the artist, often available in several languages.
+    biography(
+      # The two-letter code for the language in which to retrieve the biography.
+      lang: String = "en"
+    ): String
 
-  # The number of members in the musical group, if applicable.
-  memberCount: Int
+    # The number of members in the musical group, if applicable.
+    memberCount: Int
 
-  # A 1000x185 JPG banner image containing the artist and their logo or name.
-  banner(
-    # The size of the image to retrieve.
-    size: TheAudioDBImageSize = FULL
-  ): URLString
+    # A 1000x185 JPG banner image containing the artist and their logo or name.
+    banner(
+      # The size of the image to retrieve.
+      size: TheAudioDBImageSize = FULL
+    ): URLString
 
-  # A list of 1280x720 or 1920x1080 JPG images depicting the artist.
-  fanArt(
-    # The size of the images to retrieve.
-    size: TheAudioDBImageSize = FULL
-  ): [URLString]!
+    # A list of 1280x720 or 1920x1080 JPG images depicting the artist.
+    fanArt(
+      # The size of the images to retrieve.
+      size: TheAudioDBImageSize = FULL
+    ): [URLString]!
 
-  # A 400x155 PNG image containing the artist’s logo or name, with a transparent
-  # background.
-  logo(
-    # The size of the image to retrieve.
-    size: TheAudioDBImageSize = FULL
-  ): URLString
+    # A 400x155 PNG image containing the artist’s logo or name, with a transparent
+    # background.
+    logo(
+      # The size of the image to retrieve.
+      size: TheAudioDBImageSize = FULL
+    ): URLString
 
-  # A 1000x1000 JPG thumbnail image picturing the artist (usually containing
-  # every member of a band).
-  thumbnail(
-    # The size of the image to retrieve.
-    size: TheAudioDBImageSize = FULL
-  ): URLString
+    # A 1000x1000 JPG thumbnail image picturing the artist (usually containing
+    # every member of a band).
+    thumbnail(
+      # The size of the image to retrieve.
+      size: TheAudioDBImageSize = FULL
+    ): URLString
 
-  # The primary musical genre of the artist (e.g. “Alternative Rock”).
-  genre: String
+    # The primary musical genre of the artist (e.g. “Alternative Rock”).
+    genre: String
 
-  # The primary musical mood of the artist (e.g. “Sad”).
-  mood: String
+    # The primary musical mood of the artist (e.g. “Sad”).
+    mood: String
 
-  # The primary musical style of the artist (e.g. “Rock/Pop”).
-  style: String
-}
+    # The primary musical style of the artist (e.g. “Rock/Pop”).
+    style: String
+  }
 
-# An album on [TheAudioDB](http://www.theaudiodb.com/) corresponding with a
-# MusicBrainz Release Group.
-type TheAudioDBAlbum {
-  # TheAudioDB ID of the album.
-  albumID: ID
+  # An album on [TheAudioDB](http://www.theaudiodb.com/) corresponding with a
+  # MusicBrainz Release Group.
+  type TheAudioDBAlbum {
+    # TheAudioDB ID of the album.
+    albumID: ID
 
-  # TheAudioDB ID of the artist who released the album.
-  artistID: ID
+    # TheAudioDB ID of the artist who released the album.
+    artistID: ID
 
-  # A description of the album, often available in several languages.
-  description(
-    # The two-letter code for the language in which to retrieve the biography.
-    lang: String = "en"
-  ): String
+    # A description of the album, often available in several languages.
+    description(
+      # The two-letter code for the language in which to retrieve the biography.
+      lang: String = "en"
+    ): String
 
-  # A review of the album.
-  review: String
+    # A review of the album.
+    review: String
 
-  # The worldwide sales figure.
-  salesCount: Int
+    # The worldwide sales figure.
+    salesCount: Int
 
-  # The album’s rating as determined by user votes, out of 10.
-  score: Float
+    # The album’s rating as determined by user votes, out of 10.
+    score: Float
 
-  # The number of users who voted to determine the album’s score.
-  scoreVotes: Int
+    # The number of users who voted to determine the album’s score.
+    scoreVotes: Int
 
-  # An image of the physical disc media for the album.
-  discImage(
-    # The size of the image to retrieve.
-    size: TheAudioDBImageSize = FULL
-  ): URLString
+    # An image of the physical disc media for the album.
+    discImage(
+      # The size of the image to retrieve.
+      size: TheAudioDBImageSize = FULL
+    ): URLString
 
-  # An image of the spine of the album packaging.
-  spineImage(
-    # The size of the image to retrieve.
-    size: TheAudioDBImageSize = FULL
-  ): URLString
+    # An image of the spine of the album packaging.
+    spineImage(
+      # The size of the image to retrieve.
+      size: TheAudioDBImageSize = FULL
+    ): URLString
 
-  # An image of the front of the album packaging.
-  frontImage(
-    # The size of the image to retrieve.
-    size: TheAudioDBImageSize = FULL
-  ): URLString
+    # An image of the front of the album packaging.
+    frontImage(
+      # The size of the image to retrieve.
+      size: TheAudioDBImageSize = FULL
+    ): URLString
 
-  # An image of the back of the album packaging.
-  backImage(
-    # The size of the image to retrieve.
-    size: TheAudioDBImageSize = FULL
-  ): URLString
+    # An image of the back of the album packaging.
+    backImage(
+      # The size of the image to retrieve.
+      size: TheAudioDBImageSize = FULL
+    ): URLString
 
-  # The primary musical genre of the album (e.g. “Alternative Rock”).
-  genre: String
+    # The primary musical genre of the album (e.g. “Alternative Rock”).
+    genre: String
 
-  # The primary musical mood of the album (e.g. “Sad”).
-  mood: String
+    # The primary musical mood of the album (e.g. “Sad”).
+    mood: String
 
-  # The primary musical style of the album (e.g. “Rock/Pop”).
-  style: String
+    # The primary musical style of the album (e.g. “Rock/Pop”).
+    style: String
 
-  # A rough description of the primary musical speed of the album (e.g. “Medium”).
-  speed: String
+    # A rough description of the primary musical speed of the album (e.g. “Medium”).
+    speed: String
 
-  # The primary musical theme of the album (e.g. “In Love”).
-  theme: String
-}
+    # The primary musical theme of the album (e.g. “In Love”).
+    theme: String
+  }
 
-# A track on [TheAudioDB](http://www.theaudiodb.com/) corresponding with a
-# MusicBrainz Recording.
-type TheAudioDBTrack {
-  # TheAudioDB ID of the track.
-  trackID: ID
+  # A track on [TheAudioDB](http://www.theaudiodb.com/) corresponding with a
+  # MusicBrainz Recording.
+  type TheAudioDBTrack {
+    # TheAudioDB ID of the track.
+    trackID: ID
 
-  # TheAudioDB ID of the album on which the track appears.
-  albumID: ID
+    # TheAudioDB ID of the album on which the track appears.
+    albumID: ID
 
-  # TheAudioDB ID of the artist who released the track.
-  artistID: ID
+    # TheAudioDB ID of the artist who released the track.
+    artistID: ID
 
-  # A description of the track.
-  description(
-    lang: String = "en"
-  ): String
+    # A description of the track.
+    description(
+      # The two-letter code for the language in which to retrieve the description.
+      lang: String = "en"
+    ): String
 
-  # A thumbnail image for the track.
-  thumbnail(
-    # The size of the image to retrieve.
-    size: TheAudioDBImageSize = FULL
-  ): URLString
+    # A thumbnail image for the track.
+    thumbnail(
+      # The size of the image to retrieve.
+      size: TheAudioDBImageSize = FULL
+    ): URLString
 
-  # The track’s rating as determined by user votes, out of 10.
-  score: Float
+    # The track’s rating as determined by user votes, out of 10.
+    score: Float
 
-  # The number of users who voted to determine the album’s score.
-  scoreVotes: Int
+    # The number of users who voted to determine the album’s score.
+    scoreVotes: Int
 
-  # The track number of the song on the album.
-  trackNumber: Int
+    # The track number of the song on the album.
+    trackNumber: Int
 
-  # The official music video for the track.
-  musicVideo: TheAudioDBMusicVideo
+    # The official music video for the track.
+    musicVideo: TheAudioDBMusicVideo
 
-  # The primary musical genre of the track (e.g. “Alternative Rock”).
-  genre: String
+    # The primary musical genre of the track (e.g. “Alternative Rock”).
+    genre: String
 
-  # The primary musical mood of the track (e.g. “Sad”).
-  mood: String
+    # The primary musical mood of the track (e.g. “Sad”).
+    mood: String
 
-  # The primary musical style of the track (e.g. “Rock/Pop”).
-  style: String
+    # The primary musical style of the track (e.g. “Rock/Pop”).
+    style: String
 
-  # The primary musical theme of the track (e.g. “In Love”).
-  theme: String
-}
+    # The primary musical theme of the track (e.g. “In Love”).
+    theme: String
+  }
 
-# Details of a music video associated with a track on [TheAudioDB](http://www.theaudiodb.com/).
-type TheAudioDBMusicVideo {
-  # The URL where the music video can be found.
-  url: URLString
+  # Details of a music video associated with a track on [TheAudioDB](http://www.theaudiodb.com/).
+  type TheAudioDBMusicVideo {
+    # The URL where the music video can be found.
+    url: URLString
 
-  # The video production company of the music video.
-  companyName: String
+    # The video production company of the music video.
+    companyName: String
 
-  # The director of the music video.
-  directorName: String
+    # The director of the music video.
+    directorName: String
 
-  # A list of still images from the music video.
-  screenshots(
-    # The size of the images to retrieve.
-    size: TheAudioDBImageSize = FULL
-  ): [URLString]!
+    # A list of still images from the music video.
+    screenshots(
+      # The size of the images to retrieve.
+      size: TheAudioDBImageSize = FULL
+    ): [URLString]!
 
-  # The number of views the video has received at the given URL. This will rarely
-  # be up to date, so use cautiously.
-  viewCount: Int
+    # The number of views the video has received at the given URL. This will rarely
+    # be up to date, so use cautiously.
+    viewCount: Int
 
-  # The number of likes the video has received at the given URL. This will rarely
-  # be up to date, so use cautiously.
-  likeCount: Int
+    # The number of likes the video has received at the given URL. This will rarely
+    # be up to date, so use cautiously.
+    likeCount: Int
 
-  # The number of dislikes the video has received at the given URL. This will
-  # rarely be up to date, so use cautiously.
-  dislikeCount: Int
+    # The number of dislikes the video has received at the given URL. This will
+    # rarely be up to date, so use cautiously.
+    dislikeCount: Int
 
-  # The number of comments the video has received at the given URL. This will
-  # rarely be up to date, so use cautiously.
-  commentCount: Int
-}
+    # The number of comments the video has received at the given URL. This will
+    # rarely be up to date, so use cautiously.
+    commentCount: Int
+  }
 
-extend type Artist {
-  # Data about the artist from [TheAudioDB](http://www.theaudiodb.com/), a good
-  # source of biographical information and images.
-  # This field is provided by TheAudioDB extension.
-  theAudioDB: TheAudioDBArtist
-}
+  extend type Artist {
+    # Data about the artist from [TheAudioDB](http://www.theaudiodb.com/), a good
+    # source of biographical information and images.
+    # This field is provided by TheAudioDB extension.
+    theAudioDB: TheAudioDBArtist
+  }
 
-extend type Recording {
-  # Data about the recording from [TheAudioDB](http://www.theaudiodb.com/).
-  # This field is provided by TheAudioDB extension.
-  theAudioDB: TheAudioDBTrack
-}
+  extend type Recording {
+    # Data about the recording from [TheAudioDB](http://www.theaudiodb.com/).
+    # This field is provided by TheAudioDB extension.
+    theAudioDB: TheAudioDBTrack
+  }
 
-extend type ReleaseGroup {
-  # Data about the release group from [TheAudioDB](http://www.theaudiodb.com/),
-  # a good source of descriptive information, reviews, and images.
-  # This field is provided by TheAudioDB extension.
-  theAudioDB: TheAudioDBAlbum
-}
-
+  extend type ReleaseGroup {
+    # Data about the release group from [TheAudioDB](http://www.theaudiodb.com/),
+    # a good source of descriptive information, reviews, and images.
+    # This field is provided by TheAudioDB extension.
+    theAudioDB: TheAudioDBAlbum
+  }
 `

--- a/src/extensions/the-audio-db/schema.js
+++ b/src/extensions/the-audio-db/schema.js
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag'
+import gql from '../../tag'
 
 export default gql`
   # The image sizes that may be requested at [TheAudioDB](http://www.theaudiodb.com/).

--- a/src/tag.js
+++ b/src/tag.js
@@ -1,0 +1,15 @@
+/**
+ * This module only exists because as of this writing, `graphql-tag` doesn't
+ * support type, field, or argument descriptions. That's a bummer, so this
+ * simple tag is provided instead. It doesn't support any type of interpolation
+ * whatsoever, but will parse the GraphQL document, allow syntax highlighting,
+ * and enable Prettier formatting.
+ */
+import { parse } from 'graphql'
+
+export default function gql(literals, ...interpolations) {
+  if (literals.length !== 1 || interpolations.length) {
+    throw new Error('The gql template tag does not support interpolation.')
+  }
+  return parse(literals[0])
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,6 +96,10 @@
   dependencies:
     arrify "^1.0.1"
 
+"@types/node@*":
+  version "8.0.53"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.53.tgz#396b35af826fa66aad472c8cb7b8d5e277f4e6d8"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -194,7 +198,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.1.0:
+ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
@@ -433,6 +437,14 @@ babel-cli@^6.24.1:
     v8flags "^2.1.1"
   optionalDependencies:
     chokidar "^1.6.1"
+
+babel-code-frame@7.0.0-alpha.12:
+  version "7.0.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-7.0.0-alpha.12.tgz#26fbb2eab1c20763271fecb6b04a108756fae61f"
+  dependencies:
+    chalk "^1.1.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
 
 babel-code-frame@^6.22.0:
   version "6.22.0"
@@ -1100,6 +1112,10 @@ babel-types@^6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
+babylon@7.0.0-beta.28:
+  version "7.0.0-beta.28"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.28.tgz#14521f26a19918db2b5f4aca89e62e02e0644be7"
+
 babylon@7.0.0-beta.32, babylon@^7.0.0-beta.31:
   version "7.0.0-beta.32"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.32.tgz#e9033cb077f64d6895f4125968b37dc0a8c3bc6e"
@@ -1268,6 +1284,10 @@ camelcase-keys@^2.0.0:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
 
+camelcase@4.1.0, camelcase@^4.0.0, camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
@@ -1275,10 +1295,6 @@ camelcase@^1.0.2:
 camelcase@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
-
-camelcase@^4.0.0, camelcase@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -1299,6 +1315,14 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
+chalk@2.1.0, chalk@^2.0.0, chalk@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 chalk@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
@@ -1317,15 +1341,7 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
-  dependencies:
-    ansi-styles "^3.1.0"
-    escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
-
-chalk@^2.1.0:
+chalk@^2.1.0, chalk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
@@ -1371,6 +1387,10 @@ ci-info@^1.0.0:
 circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
+
+cjk-regex@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cjk-regex/-/cjk-regex-1.0.2.tgz#86f5170ecfaef9049ec91f8068e15d63d8e10154"
 
 clean-stack@^1.1.1:
   version "1.3.0"
@@ -1596,6 +1616,15 @@ cors@^2.8.4:
     object-assign "^4"
     vary "^1"
 
+cosmiconfig@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-3.1.0.tgz#640a94bf9847f321800403cd273af60665c73397"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^3.0.0"
+    require-from-string "^2.0.1"
+
 coveralls@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.0.tgz#22ef730330538080d29b8c151dc9146afde88a99"
@@ -1663,7 +1692,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-dashify@^0.2.2:
+dashify@0.2.2, dashify@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/dashify/-/dashify-0.2.2.tgz#6a07415a01c91faf4a32e38d9dfba71f61cb20fe"
 
@@ -1771,7 +1800,11 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-diff@^3.1.0:
+detect-newline@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
+
+diff@3.2.0, diff@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
@@ -1856,6 +1889,10 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
+emoji-regex@6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
+
 emoji-regex@~6.1.0:
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.3.tgz#ec79a3969b02d2ecf2b72254279bf99bc7a83932"
@@ -1885,7 +1922,7 @@ equal-length@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/equal-length/-/equal-length-1.0.1.tgz#21ca112d48ab24b4e1e7ffc0e5339d31fdfc274c"
 
-error-ex@^1.2.0:
+error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
@@ -1903,7 +1940,7 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.4, escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.4, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -2074,7 +2111,7 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
-esutils@^2.0.2:
+esutils@2.0.2, esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
@@ -2223,6 +2260,12 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fault@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.1.tgz#de8d350dfd48be24b5dc1b02867e0871b9135092"
+  dependencies:
+    format "^0.2.2"
+
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -2300,6 +2343,14 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+flatten@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
+
+flow-parser@0.51.1:
+  version "0.51.1"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.51.1.tgz#145d3bdce13857a72ec72938a9a700b534055b32"
+
 fn-name@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
@@ -2332,6 +2383,10 @@ form-data@~2.3.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+format@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
 
 formatio@1.2.0, formatio@^1.2.0:
   version "1.2.0"
@@ -2424,16 +2479,16 @@ get-stdin@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
 
+get-stream@3.0.0, get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
 get-stream@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
   dependencies:
     object-assign "^4.0.1"
     pinkie-promise "^2.0.0"
-
-get-stream@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -2483,22 +2538,22 @@ globals@^9.17.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
+globby@6.1.0, globby@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+  dependencies:
+    array-union "^1.0.1"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+
 globby@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
   dependencies:
     array-union "^1.0.1"
     arrify "^1.0.0"
-    glob "^7.0.3"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-
-globby@^6.0.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
-  dependencies:
-    array-union "^1.0.1"
     glob "^7.0.3"
     object-assign "^4.0.1"
     pify "^2.0.0"
@@ -2538,6 +2593,10 @@ graphql-relay@^0.5.2:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/graphql-relay/-/graphql-relay-0.5.3.tgz#56a78ac07c87d89795a34db6b8e9681b827be5b5"
 
+graphql-tag@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.5.0.tgz#b43bfd8b5babcd2c205ad680c03e98b238934e0f"
+
 graphql-tools@^2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-2.7.2.tgz#03104a155b15f8441b0e5a7113b12b9512341a9e"
@@ -2545,6 +2604,12 @@ graphql-tools@^2.7.2:
     apollo-utilities "^1.0.1"
     deprecated-decorator "^0.1.6"
     uuid "^3.1.0"
+
+graphql@0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.10.5.tgz#c9be17ca2bdfdbd134077ffd9bbaa48b8becd298"
+  dependencies:
+    iterall "^1.1.0"
 
 graphql@^0.11.7:
   version "0.11.7"
@@ -2697,7 +2762,7 @@ ignore-by-default@^1.0.0, ignore-by-default@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
 
-ignore@^3.3.3, ignore@^3.3.6:
+ignore@3.3.7, ignore@^3.3.3, ignore@^3.3.6:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
@@ -2725,6 +2790,10 @@ indent-string@^2.1.0:
 indent-string@^3.0.0, indent-string@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.1.0.tgz#08ff4334603388399b329e6b9538dc7a3cf5de7d"
+
+indexes-of@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -2818,6 +2887,10 @@ is-ci@^1.0.7:
 is-decimal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.0.tgz#940579b6ea63c628080a69e62bda88c8470b4fe0"
+
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
 
 is-dotfile@^1.0.0:
   version "1.0.2"
@@ -3053,19 +3126,42 @@ istanbul-reports@^1.1.3:
   dependencies:
     handlebars "^4.0.3"
 
-iterall@1.1.3:
+iterall@1.1.3, iterall@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
+
+jest-docblock@21.3.0-beta.7:
+  version "21.3.0-beta.7"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.3.0-beta.7.tgz#5a3cef8238fb3aedecac88a392dcfbd911ff540c"
+  dependencies:
+    detect-newline "^2.1.0"
 
 jest-docblock@^21.0.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
+
+jest-get-type@^21.0.2:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-21.2.0.tgz#f6376ab9db4b60d81e39f30749c6c466f40d4a23"
+
+jest-validate@21.1.0:
+  version "21.1.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-21.1.0.tgz#39d01115544a758bce49f221a5fcbb24ebdecc65"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^21.0.2"
+    leven "^2.1.0"
+    pretty-format "^21.1.0"
 
 jodid25519@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/jodid25519/-/jodid25519-1.0.2.tgz#06d4912255093419477d425633606e0e90782967"
   dependencies:
     jsbn "~0.1.0"
+
+js-base64@^2.1.9:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.3.2.tgz#a79a923666372b580f8e27f51845c6f7e8fbfbaf"
 
 js-string-escape@^1.0.1:
   version "1.0.1"
@@ -3079,7 +3175,7 @@ js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.6.1, js-yaml@^3.9.1:
+js-yaml@^3.6.1, js-yaml@^3.9.0, js-yaml@^3.9.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -3183,6 +3279,10 @@ lcid@^1.0.0:
 lcov-parse@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
+
+leven@2.1.0, leven@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
 
 levenshtein@1.0.2:
   version "1.0.2"
@@ -3327,6 +3427,10 @@ lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+
 lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
@@ -3439,7 +3543,7 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
-mem@^1.1.0:
+mem@1.1.0, mem@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
   dependencies:
@@ -3524,7 +3628,7 @@ mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
-minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -3534,7 +3638,7 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.3, minimist@^1.2.0, minimist@~1.2.0:
+minimist@1.2.0, minimist@^1.1.3, minimist@^1.2.0, minimist@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -3866,6 +3970,12 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse-json@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-3.0.0.tgz#fa6f47b18e23826ead32f263e744d0e1e847fb13"
+  dependencies:
+    error-ex "^1.3.1"
+
 parse-ms@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-0.1.2.tgz#dd3fa25ed6c2efc7bdde12ad9b46c163aa29224e"
@@ -3873,6 +3983,12 @@ parse-ms@^0.1.0:
 parse-ms@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-1.0.1.tgz#56346d4749d78f23430ca0c713850aef91aa361d"
+
+parse5@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  dependencies:
+    "@types/node" "*"
 
 parseurl@~1.3.2:
   version "1.3.2"
@@ -3999,6 +4115,55 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
+postcss-less@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-less/-/postcss-less-1.1.1.tgz#4bd240db517ce3407583d927858184f50045f4ab"
+  dependencies:
+    postcss "^5.2.16"
+
+postcss-media-query-parser@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
+
+postcss-scss@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-1.0.2.tgz#ff45cf3354b879ee89a4eb68680f46ac9bb14f94"
+  dependencies:
+    postcss "^6.0.3"
+
+postcss-selector-parser@2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz#f9437788606c3c9acee16ffe8d8b16297f27bb90"
+  dependencies:
+    flatten "^1.0.2"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
+postcss-values-parser@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-1.3.1.tgz#2a6ceb39cecbbacd1d060f3b16f4c52dd6720c96"
+  dependencies:
+    flatten "^1.0.2"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
+postcss@^5.2.16:
+  version "5.2.18"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
+  dependencies:
+    chalk "^1.1.3"
+    js-base64 "^2.1.9"
+    source-map "^0.5.6"
+    supports-color "^3.2.3"
+
+postcss@^6.0.3:
+  version "6.0.14"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.14.tgz#5534c72114739e75d0afcf017db853099f562885"
+  dependencies:
+    chalk "^2.3.0"
+    source-map "^0.6.1"
+    supports-color "^4.4.0"
+
 postinstall-build@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/postinstall-build/-/postinstall-build-5.0.1.tgz#b917a9079b26178d9a24af5a5cd8cb4a991d11b9"
@@ -4015,9 +4180,54 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.8.2:
+prettier@prettier/prettier#4b070c3:
   version "1.8.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.8.2.tgz#bff83e7fd573933c607875e5ba3abbdffb96aeb8"
+  resolved "https://codeload.github.com/prettier/prettier/tar.gz/4b070c3a933204befb13ece2f1c3fe6e5c127ad5"
+  dependencies:
+    babel-code-frame "7.0.0-alpha.12"
+    babylon "7.0.0-beta.28"
+    camelcase "4.1.0"
+    chalk "2.1.0"
+    cjk-regex "1.0.2"
+    cosmiconfig "3.1.0"
+    dashify "0.2.2"
+    diff "3.2.0"
+    emoji-regex "6.5.1"
+    escape-string-regexp "1.0.5"
+    esutils "2.0.2"
+    flow-parser "0.51.1"
+    get-stream "3.0.0"
+    globby "6.1.0"
+    graphql "0.10.5"
+    ignore "3.3.7"
+    jest-docblock "21.3.0-beta.7"
+    jest-validate "21.1.0"
+    leven "2.1.0"
+    mem "1.1.0"
+    minimatch "3.0.4"
+    minimist "1.2.0"
+    parse5 "3.0.3"
+    postcss-less "1.1.1"
+    postcss-media-query-parser "0.2.3"
+    postcss-scss "1.0.2"
+    postcss-selector-parser "2.2.3"
+    postcss-values-parser "1.3.1"
+    remark-frontmatter "1.1.0"
+    remark-parse "4.0.0"
+    semver "5.4.1"
+    string-width "2.1.1"
+    strip-bom "3.0.0"
+    typescript "2.5.3"
+    typescript-eslint-parser "git://github.com/eslint/typescript-eslint-parser.git#9c71a627da36e97da52ed2731d58509c952b67ae"
+    unicode-regex "1.0.1"
+    unified "6.1.5"
+
+pretty-format@^21.1.0:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
 
 pretty-ms@^0.2.1:
   version "0.2.2"
@@ -4240,6 +4450,33 @@ release-zalgo@^1.0.0:
   dependencies:
     es6-error "^4.0.1"
 
+remark-frontmatter@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remark-frontmatter/-/remark-frontmatter-1.1.0.tgz#9d23c2b376f56617bdb5c5560f1b56e45b19788b"
+  dependencies:
+    fault "^1.0.1"
+    xtend "^4.0.1"
+
+remark-parse@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-4.0.0.tgz#99f1f049afac80382366e2e0d0bd55429dd45d8b"
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.0.2"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
 remark-parse@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-1.1.0.tgz#c3ca10f9a8da04615c28f09aa4e304510526ec21"
@@ -4348,6 +4585,10 @@ request@^2.79.0, request@^2.81.0:
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+
+require-from-string@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.1.tgz#c545233e9d7da6616e9d59adfb39fc9f588676ff"
 
 require-main-filename@^1.0.1:
   version "1.0.1"
@@ -4458,6 +4699,10 @@ semver-diff@^2.0.0:
 "semver@2 || 3 || 4 || 5", semver@5.3.0, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+semver@5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
 send@0.16.1:
   version "0.16.1"
@@ -4586,6 +4831,10 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
+source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
 spawn-wrap@=1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.3.8.tgz#fa2a79b990cbb0bb0018dca6748d88367b19ec31"
@@ -4654,6 +4903,13 @@ stream-combiner@~0.0.4:
   dependencies:
     duplexer "~0.1.1"
 
+string-width@2.1.1, string-width@^2.1.0, string-width@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
+
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -4668,13 +4924,6 @@ string-width@^2.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^3.0.0"
-
-string-width@^2.1.0, string-width@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
-  dependencies:
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^4.0.0"
 
 string_decoder@~1.0.0:
   version "1.0.1"
@@ -4724,15 +4973,15 @@ strip-bom-buf@^1.0.0:
   dependencies:
     is-utf8 "^0.2.1"
 
+strip-bom@3.0.0, strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
   dependencies:
     is-utf8 "^0.2.0"
-
-strip-bom@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
 strip-eof@^1.0.0:
   version "1.0.0"
@@ -4758,7 +5007,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.2:
+supports-color@^3.1.2, supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
@@ -4963,6 +5212,17 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#9c71a627da36e97da52ed2731d58509c952b67ae":
+  version "8.0.0"
+  resolved "git://github.com/eslint/typescript-eslint-parser.git#9c71a627da36e97da52ed2731d58509c952b67ae"
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.4.1"
+
+typescript@2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
+
 uglify-js@^2.6:
   version "2.8.27"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.27.tgz#47787f912b0f242e5b984343be8e35e95f694c9c"
@@ -4999,6 +5259,22 @@ unherit@^1.0.4:
     inherits "^2.0.1"
     xtend "^4.0.1"
 
+unicode-regex@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unicode-regex/-/unicode-regex-1.0.1.tgz#f819e050191d5b9561a339a58dd3b9095ed94b35"
+
+unified@6.1.5, unified@^6.1.2:
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.1.5.tgz#716937872621a63135e62ced2f3ac6a063c6fb87"
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^1.1.0"
+    trough "^1.0.0"
+    vfile "^2.0.0"
+    x-is-function "^1.0.4"
+    x-is-string "^0.1.0"
+
 unified@^4.1.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/unified/-/unified-4.2.1.tgz#76ff43aa8da430f6e7e4a55c84ebac2ad2cfcd2e"
@@ -5010,17 +5286,9 @@ unified@^4.1.1:
     trough "^1.0.0"
     vfile "^1.0.0"
 
-unified@^6.1.2:
-  version "6.1.5"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-6.1.5.tgz#716937872621a63135e62ced2f3ac6a063c6fb87"
-  dependencies:
-    bail "^1.0.0"
-    extend "^3.0.0"
-    is-plain-obj "^1.1.0"
-    trough "^1.0.0"
-    vfile "^2.0.0"
-    x-is-function "^1.0.4"
-    x-is-string "^0.1.0"
+uniq@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
 
 unique-string@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2593,10 +2593,6 @@ graphql-relay@^0.5.2:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/graphql-relay/-/graphql-relay-0.5.3.tgz#56a78ac07c87d89795a34db6b8e9681b827be5b5"
 
-graphql-tag@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.5.0.tgz#b43bfd8b5babcd2c205ad680c03e98b238934e0f"
-
 graphql-tools@^2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-2.7.2.tgz#03104a155b15f8441b0e5a7113b12b9512341a9e"


### PR DESCRIPTION
This also causes Prettier to format the GraphQL contents, so use current Prettier `master` to get prettier/prettier#3252 (prettier/prettier#3251).