### PR TITLE
Extension field fixes

### DIFF
--- a/src/extensions/fanart-tv/resolvers.js
+++ b/src/extensions/fanart-tv/resolvers.js
@@ -22,23 +22,23 @@ export default {
   },
   FanArtArtist: {
     backgrounds: artist => {
-      return artist.artistbackground
+      return artist.artistbackground || []
     },
     thumbnails: artist => {
-      return artist.artistthumb
+      return artist.artistthumb || []
     },
     logos: artist => {
-      return artist.musiclogo
+      return artist.musiclogo || []
     },
     logosHD: artist => {
-      return artist.hdmusiclogo
+      return artist.hdmusiclogo || []
     },
     banners: artist => {
-      return artist.musicbanner
+      return artist.musicbanner || []
     }
   },
   FanArtLabel: {
-    logos: label => label.musiclabel
+    logos: label => label.musiclabel || []
   },
   FanArtAlbum: {
     albumCovers: album => album.albumcover || [],

--- a/src/extensions/the-audio-db/resolvers.js
+++ b/src/extensions/the-audio-db/resolvers.js
@@ -74,7 +74,15 @@ export default {
     theme: track => track.strTheme || null
   },
   TheAudioDBMusicVideo: {
-    url: track => track.strMusicVid || null,
+    url: track => {
+      let url = track.strMusicVid || null
+      // Many of these are missing the protocol and start with www, so add it
+      // in that case.
+      if (url && url.startsWith('www.')) {
+        url = `https://${url}`
+      }
+      return url
+    },
     companyName: track => track.strMusicVidCompany || null,
     directorName: track => track.strMusicVidDirector || null,
     screenshots: handleImageSize(track => {


### PR DESCRIPTION
* Some TheAudioDB music video URLs do not include the protocol. Add it automatically (assume `https:`) instead of returning null with an error.
* Correctly return empty arrays instead of null for empty fanart.tv image lists